### PR TITLE
Use "sas2ircu" command to physically locate disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ system, the following packages should be there:
 * freeipmi
 * smartmontools
 * hdparm
+
+In addition, the script tries to use the "sas2ircu" command to obtain
+physical location information about the broken disk.  This program is
+specific to LSI disk controllers and can be obtained from the vendor.

--- a/bdsm-info
+++ b/bdsm-info
@@ -376,6 +376,84 @@ sub collect_disk_information_using_smartctl($ ) {
     }
 }
 
+sub collect_disk_location_information_using_sas2ircu($ ) {
+    my ($disk) = @_;
+    my %controller = ();
+
+    open PIPE, "sudo sas2ircu list|"
+	or die "Cannot run sas2ircu list: $!";
+    while (<PIPE>) {
+	my (@m);
+	if (@m = /^\s+(\d+)\s+(\S+)\s+([0-9a-f]+)h\s+([0-9a-f]+)h\s+([0-9a-f]+)h:([0-9a-f]+)h:([0-9a-f]+)h:([0-9a-f]+)h\s+([0-9a-f]+)h\s+([0-9a-f]+)h\s*$/) {
+	    my ($idx, $type) = @m;
+	    $controller{$idx} = {
+		index => $idx,
+		type => $type,
+	    };
+	} else {
+	    # warn "Cannot parse line:\n$_\n";
+	}
+    }
+    close PIPE
+	or die "Error from sudo sas2ircu list: $!";
+    foreach my $idx (sort keys %controller) {
+	my ($type);
+	my %attrval = ();
+	$type = $controller{$idx}->{type};
+	open PIPE, "sudo sas2ircu $idx display|"
+	    or die "Cannot run sas2ircu $idx display: $!";
+	while (<PIPE>) {
+	    my (@m);
+	    # Enclosure #                             : 1
+	    # Slot #                                  : 0
+	    # SAS Address                             : 4433221-1-0000-0000
+	    # State                                   : Ready (RDY)
+	    # Size (in MB)/(in sectors)               : 3815447/7814037167
+	    # Manufacturer                            : ATA
+	    # Model Number                            : WDC WD4000F9YZ-0
+	    # Firmware Revision                       : 1A01
+	    # Serial No                               : WDWCC131695593
+	    # GUID                                    : 50014ee2b478ab80
+	    # Protocol                                : SATA
+	    # Drive Type                              : SATA_HDD
+	    if (@m = /^  (Enclosure #|Slot #|SAS Address|State|Size \(in MB\)\/\(in sectors\)|Manufacturer|Model Number|Firmware Revision|Serial No|GUID|Protocol|Drive Type)\s*: (.*)$/) {
+		my ($attr, $val) = @m;
+		$attrval{$attr} = $val;
+	    } elsif (/^$/ or /^----/) {
+		if (exists $attrval{'Enclosure #'}
+		    and exists $attrval{'Slot #'}) {
+		    my ($enc, $slot);
+		    $enc = $attrval{'Enclosure #'};
+		    $slot = $attrval{'Slot #'};
+		    # $controller{$idx}->{disk} = {}
+		    # unless exists $controller{$idx}->{disk};
+		    my %attrcopy = %attrval;
+		    $controller{$idx}->{disk}->{$enc,$slot} = \%attrcopy;
+		} else {
+		    # warn "Missing Enclosure/Slot #";
+		}
+		%attrval = ();
+	    } else {
+		# warn "Cannot parse line:\n$_\n";
+	    }
+	}
+	close PIPE
+	    or warn "Error from sudo sas2ircu $idx display: $!";
+    }
+    foreach my $index (sort keys %controller) {
+	my $controller = $controller{$index};
+	foreach my $encslot (sort keys %{$controller->{disk}}) {
+	    my ($enc, $slot) = split($;,$encslot);
+	    my $d = $controller->{disk}->{$encslot};
+	    if ($d->{GUID} eq $disk->{wwn}) {
+		$disk->{controller_index} = $index;
+		$disk->{enclosure_index} = $enc;
+		$disk->{enclosure_slot} = $slot;
+	    }
+	}
+    }
+}
+
 sub check_udev_rules($$) {
     my ($disk, $rules_file) = @_;
     my (@m);
@@ -479,6 +557,13 @@ sub suggest_ticket_mail($$) {
 
     printf STDOUT ("WWN:                   %s\n", $disk->{wwn});
     printf STDOUT ("Target:                %s\n", $disk->{target});
+    printf STDOUT ("Locator LED:           sudo sas2ircu %s locate %s:%s on/off\n",
+		   $disk->{controller_index},
+		   $disk->{enclosure_index},
+		   $disk->{enclosure_slot})
+	if (exists $disk->{controller_index}
+	    and exists $disk->{enclosure_index}
+	    and exists $disk->{enclosure_slot});
 
     if (exists $disk->{mountpoints}) {
 	foreach my $mountpoint (sort keys %{$disk->{mountpoints}}) {
@@ -557,6 +642,7 @@ sub collect_disk_information($ ) {
 	warn "'smartctl' not found.  Please install smartmontools.\n";
 	collect_disk_information_using_hdparm($disk_errors);
     }
+    collect_disk_location_information_using_sas2ircu($disk_errors);
 }
 
 my $errors = trawl_logs_for_disk_errors();

--- a/bdsm-info
+++ b/bdsm-info
@@ -380,8 +380,10 @@ sub collect_disk_location_information_using_sas2ircu($ ) {
     my ($disk) = @_;
     my %controller = ();
 
-    open PIPE, "sudo sas2ircu list|"
-	or die "Cannot run sas2ircu list: $!";
+    unless (open PIPE, "sudo sas2ircu list|") {
+	warn "Cannot run sas2ircu list: $!";
+	return undef;
+    }
     while (<PIPE>) {
 	my (@m);
 	if (@m = /^\s+(\d+)\s+(\S+)\s+([0-9a-f]+)h\s+([0-9a-f]+)h\s+([0-9a-f]+)h:([0-9a-f]+)h:([0-9a-f]+)h:([0-9a-f]+)h\s+([0-9a-f]+)h\s+([0-9a-f]+)h\s*$/) {
@@ -394,8 +396,9 @@ sub collect_disk_location_information_using_sas2ircu($ ) {
 	    # warn "Cannot parse line:\n$_\n";
 	}
     }
-    close PIPE
-	or die "Error from sudo sas2ircu list: $!";
+    if (close PIPE) {
+	warn "Error from sudo sas2ircu list: $!";
+    }
     foreach my $idx (sort keys %controller) {
 	my ($type);
 	my %attrval = ();


### PR DESCRIPTION
The sas2ircu command can be used to enumerate SAS controllers and the
disks attached to them, and to obtain information such as the physical
enclosure and the slot within an enclosure where a disk is located.  If
the script manages to obtain that information for the disk in question,
it will now output the sas2ircu commands to turn the locator LED on and
off, which is very handy for disk replacement.
Closes #1.
