### PR TITLE
Fix test for error from sas2ircu -l

### DIFF
--- a/bdsm-info
+++ b/bdsm-info
@@ -398,7 +398,7 @@ sub collect_disk_location_information_using_sas2ircu($ ) {
 	    # warn "Cannot parse line:\n$_\n";
 	}
     }
-    if (close PIPE) {
+    unless (close PIPE) {
 	warn "Error from sudo sas2ircu list: $!";
     }
     foreach my $idx (sort keys %controller) {


### PR DESCRIPTION
The if() condition was inverted.

Addresses #1.
