### PR TITLE
SAS 3008 support fixes

### DIFF
--- a/bdsm-info
+++ b/bdsm-info
@@ -458,19 +458,22 @@ sub collect_disk_location_information_using_sasNircu($$) {
 	close PIPE
 	    or warn "Error from sudo $sasNircu $idx display: $!";
     }
+    my $found_disk = 0;
     foreach my $index (sort keys %controller) {
 	my $controller = $controller{$index};
 	foreach my $encslot (sort keys %{$controller->{disk}}) {
 	    my ($enc, $slot) = split($;,$encslot);
 	    my $d = $controller->{disk}->{$encslot};
 	    if ($d->{GUID} eq $disk->{wwn}) {
+		$found_disk = 1;
+		$disk->{sasNircu} = $sasNircu;
 		$disk->{controller_index} = $index;
 		$disk->{enclosure_index} = $enc;
 		$disk->{enclosure_slot} = $slot;
 	    }
 	}
     }
-    1;
+    $found_disk;
 }
 
 sub check_udev_rules($$) {
@@ -566,7 +569,8 @@ sub suggest_ticket_mail($$) {
 	if exists $disk->{symlink};
     printf STDOUT ("WWN:                   %s\n", $disk->{wwn});
     printf STDOUT ("Target:                %s\n", $disk->{target});
-    printf STDOUT ("Locator LED:           sudo sas2ircu %s locate %s:%s on/off\n",
+    printf STDOUT ("Locator LED:           sudo %s %s locate %s:%s on/off\n",
+		   $disk->{sasNircu},
 		   $disk->{controller_index},
 		   $disk->{enclosure_index},
 		   $disk->{enclosure_slot})

--- a/bdsm-info
+++ b/bdsm-info
@@ -410,7 +410,8 @@ sub collect_disk_location_information_using_sasNircu($$) {
 	}
     }
     unless (close PIPE) {
-	warn "Error from sudo $sasNircu list: $!";
+	warn "Error from sudo $sasNircu list";
+	return undef;
     }
     foreach my $idx (sort keys %controller) {
 	my ($type);

--- a/bdsm-info
+++ b/bdsm-info
@@ -396,6 +396,8 @@ sub collect_disk_location_information_using_sasNircu($$) {
 	return undef;
     }
     while (<PIPE>) {
+	warn "SAS${n}IRCU: $_"
+	    if $debug;
 	my (@m);
 	if (@m = /^\s+(\d+)\s+(\S+)\s+([0-9a-f]+)h\s+([0-9a-f]+)h\s+([0-9a-f]+)h:([0-9a-f]+)h:([0-9a-f]+)h:([0-9a-f]+)h\s+([0-9a-f]+)h\s+([0-9a-f]+)h\s*$/) {
 	    my ($idx, $type) = @m;

--- a/bdsm-info
+++ b/bdsm-info
@@ -391,6 +391,7 @@ sub collect_disk_location_information_using_sasNircu($$) {
     my %controller = ();
     my $sasNircu = "sas${n}ircu";
 
+    return undef unless find_in_path ($sasNircu);
     unless (open PIPE, "sudo $sasNircu list|") {
 	warn "Cannot run $sasNircu list: $!";
 	return undef;


### PR DESCRIPTION
This fixes a few issues from the first attempt at supporting the SAS 3008:

The code will now properly fall through to SAS 2008 (sas2ircu) in cases where sas3ircu isn't installed, doesn't work, or doesn't find the disk in question.

The script will also now output the correct command (sas2ircu or sas3ircu) to turn the locator LED on and off.

Closes #38