### PR TITLE
Try a bit harder to find attrlog file for device

### DIFF
--- a/bdsm-info
+++ b/bdsm-info
@@ -338,12 +338,27 @@ sub collect_disk_information_using_hdparm($ ) {
 	or die "Error from sudo hdparm -I $dev: $!";
 }
 
-sub collect_smart_hist($ ) {
+sub find_smart_attrlog($ ) {
     my ($disk) = @_;
     my $smartpath = $disk->{model};
-    $smartpath =~ s/ /_/g;
-    $smartpath .= '-'.$disk->{serno};
-    my $smarthistfile = $smartstore.'/attrlog.'.$smartpath.'.ata.csv';
+    my $serno = $disk->{serno};
+    $smartpath =~ s/[- ]/_/g;
+    my $smarthistfile = $smartstore.'/attrlog.'.$smartpath.'-'.$serno.'.ata.csv';
+    return $smarthistfile if -f $smarthistfile;
+    $serno =~ s/[- ]/_/g;
+    $smarthistfile = $smartstore.'/attrlog.'.$smartpath.'-'.$serno.'.ata.csv';
+    return $smarthistfile if -f $smarthistfile;
+    return undef;
+}
+
+sub collect_smart_hist($ ) {
+    my ($disk) = @_;
+    my $smarthistfile = find_smart_attrlog($disk);
+    if (! defined $smarthistfile) {
+	warn "Could not find attrlog file for serno "
+	    .$disk->{serno}."/model ".$disk->{model}."\n";
+	return undef;
+    }
     if (open SMARTHIST, $smarthistfile) {
 	$disk->{smarthist} = {'hist' => {}};
 	my ($first_datetime, $last_datetime);


### PR DESCRIPTION
There seem to be two different naming conventions in the wild, namely

* attrlog.WDC_WD4000F9YZ-09N20L0-WD-WCC131673154.ata.csv
* attrlog.WDC_WD4000F9YZ_09N20L0-WD_WCC131673154.ata.csv

That is, sometimes dashes in the serial number are replaced by
underscores, sometimes not.  We try to support both.